### PR TITLE
:art: Atualiza gulp-sass para resolver conflitos com versoes do node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-colorpicker",
   "version": "1.1.2",
+  
   "description": "angular-colorpicker",
   "main": "./dist/js/angular-colorpicker.min.js",
   "style": "./dist/css/angular-colorpicker.min.css",
@@ -19,7 +20,7 @@
     "color",
     "angular"
   ],
-  "author": "linjinying",
+  "author": "erictonussi",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/linjinying/angular-colorpicker/issues"
@@ -29,7 +30,7 @@
     "gulp": "^3.9.0",
     "gulp-minify-css": "^1.2.3",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.1.1",
+    "gulp-sass": "^5.1.0",
     "gulp-uglify": "^1.5.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-compass": "^2.1.0",


### PR DESCRIPTION
Não é mais possível instalar o pacote via NPM porque a versão do `gulp-sass` referenciada no package.json não é compatível com as versões mais atuais do node. A alteração proposta, basicamente, é atualizar esta dependência para se tornar compatível com a versão 17 do Node.js.